### PR TITLE
Fixed parsing Teleporters without names and their associated links.

### DIFF
--- a/src/Components/Panels/Inventory/ObstacleSummary.tsx
+++ b/src/Components/Panels/Inventory/ObstacleSummary.tsx
@@ -55,16 +55,36 @@ const ObstacleSummary = forwardRef<HTMLDivElement, Props>(
     const displayName =
       obstacle.name || `${obstacle._objectType} ${obstacle._uuid.substr(0, 8)}`;
 
-    return (
-      <div
-        ref={ref}
-        className={`${styles.wrapper} ${selected && styles.selected}`}
-        onClick={(event) => onClick(event, obstacle)}
-      >
-        <div>{getThumbnail(obstacle)}</div>
-        <div className={styles.body}>{displayName}</div>
-      </div>
-    );
+    if (obstacle._objectType === 'link') {
+      // temporary display for link details
+      return (
+        <div
+          ref={ref}
+          className={`${styles.wrapper} ${selected && styles.selected}`}
+          onClick={(event) => onClick(event, obstacle)}
+        >
+          <div>{getThumbnail(obstacle)}</div>
+          <div className={styles.body}>
+            {displayName}
+            <br />
+            from = {obstacle.from.name}:{obstacle.from.side}
+            <br />
+            to = {obstacle.to.name}:{obstacle.to.side}
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div
+          ref={ref}
+          className={`${styles.wrapper} ${selected && styles.selected}`}
+          onClick={(event) => onClick(event, obstacle)}
+        >
+          <div>{getThumbnail(obstacle)}</div>
+          <div className={styles.body}>{displayName}</div>
+        </div>
+      );
+    }
   },
 );
 

--- a/src/Document/Obstacles/World.ts
+++ b/src/Document/Obstacles/World.ts
@@ -1,6 +1,7 @@
 import { INameable } from '../Attributes/INameable';
 import { bzwBool, bzwFloat, bzwString } from '../attributeParsers';
 import { IBaseObject, newIBaseObject } from './BaseObject';
+import { TeleporterReference } from './TeleporterLink';
 
 export const WorldProperties = {
   name: bzwString,
@@ -11,6 +12,7 @@ export const WorldProperties = {
 };
 
 export interface IWorld extends IBaseObject, INameable {
+  _teleporters: TeleporterReference[];
   size: number;
   flagheight?: number;
   nowalls: boolean;
@@ -20,6 +22,7 @@ export interface IWorld extends IBaseObject, INameable {
 export function newIWorld(): IWorld {
   return {
     ...newIBaseObject('world'),
+    _teleporters: [],
     size: 800,
     nowalls: false,
     freectfspawns: false,

--- a/src/Document/__tests__/parseBZWDocument.ts
+++ b/src/Document/__tests__/parseBZWDocument.ts
@@ -172,6 +172,27 @@ describe('BZW Document Parser', () => {
     expect(teleporter.border).toEqual(1.12);
   });
 
+  it('should handle a teleporter with no name', () => {
+    const bzwBody = `\
+    teleporter
+      position 0 0 10
+      size 0.125 5 20
+      rotation 45
+      border 1.12
+    end
+    `;
+    const world = parseBZWDocument(bzwBody);
+    const teleporter: ITeleporter = Object.values(
+      world.children,
+    ).pop() as ITeleporter;
+
+    expect(teleporter.name).toEqual('teleporter 0');
+    expect(teleporter.position).toEqual([0, 0, 10]);
+    expect(teleporter.size).toEqual([0.125, 5, 20]);
+    expect(teleporter.rotation).toEqual(45);
+    expect(teleporter.border).toEqual(1.12);
+  });
+
   it('should handle a link', () => {
     const bzwBody = `\
     link
@@ -211,6 +232,39 @@ describe('BZW Document Parser', () => {
     expect(link.from.side).toEqual(TeleporterSide.Both);
     expect(link.to.name).toEqual('tele2');
     expect(link.to.side).toEqual(TeleporterSide.Both);
+  });
+
+  it('should handle a link with from/to defined as a single number', () => {
+    const bzwBody = `\
+    teleporter MyTele
+      position     390.0 390.0 0.0
+      rotation     45.0
+      size         0.56  4.48  27.7
+      border       1.12
+    end
+
+    teleporter
+      position     390.0 390.0 30.0
+      rotation     45.0
+      size         0.56  4.48  15.0
+      border       1.12
+    end
+
+    link
+      from 1
+      to 2
+    end
+    `;
+
+    const world = parseBZWDocument(bzwBody);
+    const link: ITeleporterLink = Object.values(
+      world.children,
+    ).pop() as ITeleporterLink;
+
+    expect(link.from.name).toEqual('MyTele');
+    expect(link.from.side).toEqual(TeleporterSide.Backward);
+    expect(link.to.name).toEqual('teleporter 1');
+    expect(link.to.side).toEqual(TeleporterSide.Forward);
   });
 
   it('should handle a mesh', () => {

--- a/src/Document/attributeParsers.ts
+++ b/src/Document/attributeParsers.ts
@@ -1,3 +1,4 @@
+import { ITeleporter } from './Obstacles/Teleporter';
 import {
   TeleporterReference,
   TeleporterSide,
@@ -69,6 +70,7 @@ export function bzwVector4F(line: string): [number, number, number, number] {
   ];
 }
 
+export const teleporters = new Array<ITeleporter>();
 export function bzwTeleRef(line: string): TeleporterReference {
   let name = line;
   let side = TeleporterSide.Both;
@@ -83,6 +85,14 @@ export function bzwTeleRef(line: string): TeleporterReference {
     } else if (sideStr === 'b') {
       side = TeleporterSide.Backward;
     }
+  } else if (!isNaN(+name)) {
+    // teleporter reference was defined as a single number
+    // determine which teleporter and side is being referenced
+    const teleIndex = Math.floor(+name / 2),
+      sideIndex = +name % 2;
+
+    name = teleporters[teleIndex].name ?? '';
+    side = sideIndex === 0 ? TeleporterSide.Forward : TeleporterSide.Backward;
   }
 
   return {

--- a/src/Document/attributeParsers.ts
+++ b/src/Document/attributeParsers.ts
@@ -1,10 +1,10 @@
-import { ITeleporter } from './Obstacles/Teleporter';
 import {
   TeleporterReference,
   TeleporterSide,
 } from './Obstacles/TeleporterLink';
+import { IWorld } from './Obstacles/World';
 
-export type ParserCallback<T> = (line: string) => T;
+export type ParserCallback<T> = (line: string, world: IWorld) => T;
 
 export interface Repeatable<T> {
   type: 'repeatable';
@@ -70,8 +70,7 @@ export function bzwVector4F(line: string): [number, number, number, number] {
   ];
 }
 
-export const teleporters = new Array<ITeleporter>();
-export function bzwTeleRef(line: string): TeleporterReference {
+export function bzwTeleRef(line: string, world: IWorld): TeleporterReference {
   let name = line;
   let side = TeleporterSide.Both;
   const i = line.lastIndexOf(':');
@@ -91,7 +90,7 @@ export function bzwTeleRef(line: string): TeleporterReference {
     const teleIndex = Math.floor(+name / 2),
       sideIndex = +name % 2;
 
-    name = teleporters[teleIndex].name ?? '';
+    name = world._teleporters[teleIndex].name ?? '';
     side = sideIndex === 0 ? TeleporterSide.Forward : TeleporterSide.Backward;
   }
 

--- a/src/Document/parseBZWDocument.ts
+++ b/src/Document/parseBZWDocument.ts
@@ -8,7 +8,11 @@ import { MaterialProperties, newIMaterial } from './Obstacles/Material';
 import { MeshProperties, newIMesh } from './Obstacles/Mesh';
 import { MeshFaceProperties, newIMeshFace } from './Obstacles/MeshFace';
 import { newIPyramid, PyramidProperties } from './Obstacles/Pyramid';
-import { newITeleporter, TeleporterProperties } from './Obstacles/Teleporter';
+import {
+  ITeleporter,
+  newITeleporter,
+  TeleporterProperties,
+} from './Obstacles/Teleporter';
 import {
   newITeleporterLink,
   TeleporterLinkProperties,
@@ -113,6 +117,7 @@ export function parseBZWDocument(document: string): IWorld {
 
   const lines = document.split('\n');
   const objStack = new Stack<IBaseObject>([world]);
+  teleporters.length = 0;
 
   for (const _line of lines) {
     const line = _line.trim();

--- a/src/Document/parseBZWDocument.ts
+++ b/src/Document/parseBZWDocument.ts
@@ -8,11 +8,7 @@ import { MaterialProperties, newIMaterial } from './Obstacles/Material';
 import { MeshProperties, newIMesh } from './Obstacles/Mesh';
 import { MeshFaceProperties, newIMeshFace } from './Obstacles/MeshFace';
 import { newIPyramid, PyramidProperties } from './Obstacles/Pyramid';
-import {
-  ITeleporter,
-  newITeleporter,
-  TeleporterProperties,
-} from './Obstacles/Teleporter';
+import { newITeleporter, TeleporterProperties } from './Obstacles/Teleporter';
 import {
   newITeleporterLink,
   TeleporterLinkProperties,


### PR DESCRIPTION
Closes https://github.com/allejo/WebBZEdit/issues/8.

Teleporters without names will now be assigned a generated name like "teleporter [index]" where [index] indicates the teleporter's position in the document. For example, the first teleporter defined in the document is "teleporter 0", the second teleporter is "teleporter 1", and so on.

Links that have their "from" and/or "to" attributes defined as a single number (i.e. `from 0`) are assumed to be referencing a teleporter side given that each teleporter has two sides.
For example,
```
link
  from 1
  to 4
end
```
means the link goes from the backward side of teleporter 0 to the forward side of teleporter 2.

Named teleporters and links explicitly referencing teleporters and sides (i.e. `from MyTele:f`) are still supported.