### PR TITLE
Stop event propagation on 3D models for hovering + clicking

### DIFF
--- a/src/3DModels/Abstract/SkinnableBox.tsx
+++ b/src/3DModels/Abstract/SkinnableBox.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, MouseEvent, PointerEvent } from 'react';
 import { useUpdate } from 'react-three-fiber';
 import { EdgesGeometry, LineSegments, Mesh, Texture } from 'three';
 
@@ -48,14 +48,27 @@ const SkinnableBox = ({
   );
   const isHighlighted = isSelectable && (hover || isSelected);
 
+  const handleOnClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    onClick(e);
+  };
+  const handlePointerOver = (e: PointerEvent) => {
+    e.stopPropagation();
+    setHover(true);
+  };
+  const handlePointerOut = (e: PointerEvent) => {
+    e.stopPropagation();
+    setHover(false);
+  };
+
   return (
     <mesh
       ref={mesh}
       position={[bzwPosX, bzwPosZ + bzwSizeZ / 2, -bzwPosY]}
       rotation={[0, deg2rad(rotation), 0]}
-      onClick={onClick}
-      onPointerOver={() => setHover(true)}
-      onPointerOut={() => setHover(false)}
+      onClick={handleOnClick}
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
     >
       <boxBufferGeometry
         attach="geometry"

--- a/src/3DModels/Teleporter.tsx
+++ b/src/3DModels/Teleporter.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { MouseEvent, PointerEvent, useState } from 'react';
 import { useLoader, useUpdate } from 'react-three-fiber';
 import {
   BoxBufferGeometry,
@@ -27,7 +27,19 @@ const Teleporter = ({ obstacle, isSelected, onClick }: Props) => {
   const { position, size, rotation = 0, border } = obstacle;
   const [bzwPosX, bzwPosY, bzwPosZ] = position;
   const [, bzwSizeY, bzwSizeZ] = size;
-  const handleOnClick = () => onClick(obstacle);
+
+  const handleOnClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    onClick(obstacle);
+  };
+  const handlePointerOver = (e: PointerEvent) => {
+    e.stopPropagation();
+    setHover(true);
+  };
+  const handlePointerOut = (e: PointerEvent) => {
+    e.stopPropagation();
+    setHover(false);
+  };
 
   const segments = useUpdate<LineSegments>(
     (s) => {
@@ -110,8 +122,8 @@ const Teleporter = ({ obstacle, isSelected, onClick }: Props) => {
     <mesh
       position={[bzwPosX, bzwPosZ, bzwPosY]}
       rotation={[0, -deg2rad(rotation), 0]}
-      onPointerOver={() => setHover(true)}
-      onPointerOut={() => setHover(false)}
+      onPointerOver={handlePointerOver}
+      onPointerOut={handlePointerOut}
     >
       {/* === Link material === */}
       <SkinnableBox


### PR DESCRIPTION
Stop event propagation as soon as the first model is clicked or hovered over. This will ensure that that only one model will have the hover and click effect.

Fixes #10
