### PR TITLE
Add editor for teleporter links

### DIFF
--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -24,7 +24,7 @@
   background-color: $color-grey-dark;
   color: $color-white;
   grid-area: Toolbox;
-  height: 180px;
+  max-height: 25vh;
   padding: 1rem;
 }
 

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -24,6 +24,7 @@
   background-color: $color-grey-dark;
   color: $color-white;
   grid-area: Toolbox;
+  height: 180px;
   padding: 1rem;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import HixDocumentLoader from './Components/HixDocumentLoader';
 import AboutModal from './Components/Modals/AboutModal';
 import FlagSettingsModal from './Components/Modals/FlagSettingsModal';
+import TeleporterLinkEditorModal from './Components/Modals/TeleporterLinkEditorModal';
 import WorldSettingsModal from './Components/Modals/WorldSettingsModal';
 import InventoryPanel from './Components/Panels/InventoryPanel';
 import MenubarPanel from './Components/Panels/MenubarPanel';
@@ -36,6 +37,7 @@ const App: React.FC = () => (
       <AboutModal />
       <FlagSettingsModal />
       <WorldSettingsModal />
+      <TeleporterLinkEditorModal />
     </>
   </div>
 );

--- a/src/Components/Alert.module.scss
+++ b/src/Components/Alert.module.scss
@@ -1,0 +1,48 @@
+.wrapper {
+  color: white;
+  display: flex;
+  padding: 1rem;
+}
+
+.styleInfo {
+  background-color: #277aa9;
+}
+
+.styleSuccess {
+  background-color: #397e35;
+}
+
+.styleWarning {
+  background-color: #846d1f;
+}
+
+.styleDanger {
+  background-color: #d9403d;
+}
+
+.iconContainer {
+  align-items: center;
+  display: flex;
+  margin-right: 0.75rem;
+}
+
+.bodyContainer {
+}
+
+.dismissContainer {
+  align-items: center;
+  display: flex;
+  margin-left: auto;
+  padding-left: 0.75rem;
+}
+
+.dismissButton {
+  appearance: none;
+  background-color: transparent;
+  border: 0;
+  color: white;
+}
+
+.header {
+  font-weight: bold;
+}

--- a/src/Components/Alert.tsx
+++ b/src/Components/Alert.tsx
@@ -49,14 +49,13 @@ const Alert = ({
   children,
 }: Props) => {
   const [dismissed, setDismissed] = useState(false);
-  const onDismissClick = () => {
-    setDismissed(true);
-  };
-  const classes = classList([styles.wrapper, CSSStyles[type], className]);
 
   if (dismissed) {
     return null;
   }
+
+  const onDismissClick = () => setDismissed(true);
+  const classes = classList([styles.wrapper, CSSStyles[type], className]);
 
   return (
     <div className={classes} role="alert">

--- a/src/Components/Alert.tsx
+++ b/src/Components/Alert.tsx
@@ -1,0 +1,87 @@
+import { IconDefinition } from '@fortawesome/fontawesome-common-types';
+import {
+  faCheck,
+  faExclamationTriangle,
+  faInfoCircle,
+  faTimes,
+  faTimesCircle,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { HTMLAttributes, ReactNode, useState } from 'react';
+
+import { classList } from '../Utilities/cssClasses';
+
+import styles from './Alert.module.scss';
+
+export enum AlertType {
+  Info,
+  Success,
+  Warning,
+  Danger,
+}
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  type: AlertType;
+  header: ReactNode;
+  isDismissible?: boolean;
+  children: ReactNode;
+}
+
+const CSSStyles: Record<AlertType, string> = {
+  [AlertType.Info]: styles.styleInfo,
+  [AlertType.Success]: styles.styleSuccess,
+  [AlertType.Warning]: styles.styleWarning,
+  [AlertType.Danger]: styles.styleDanger,
+};
+
+const Icons: Record<AlertType, IconDefinition> = {
+  [AlertType.Info]: faInfoCircle,
+  [AlertType.Success]: faCheck,
+  [AlertType.Warning]: faExclamationTriangle,
+  [AlertType.Danger]: faTimesCircle,
+};
+
+const Alert = ({
+  className,
+  header,
+  isDismissible = false,
+  type,
+  children,
+}: Props) => {
+  const [dismissed, setDismissed] = useState(false);
+  const onDismissClick = () => {
+    setDismissed(true);
+  };
+  const classes = classList([styles.wrapper, CSSStyles[type], className]);
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <div className={classes} role="alert">
+      <div className={styles.iconContainer}>
+        <FontAwesomeIcon fixedWidth={true} icon={Icons[type]} />
+      </div>
+      <div className={styles.bodyContainer}>
+        <header className={styles.header}>{header}</header>
+
+        {children}
+      </div>
+      {isDismissible && (
+        <div className={styles.dismissContainer}>
+          <button
+            className={styles.dismissButton}
+            aria-label="Dismiss alert"
+            onClick={onDismissClick}
+          >
+            <FontAwesomeIcon icon={faTimes} />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Alert;
+export type { Props as IAlertProps };

--- a/src/Components/Form/BaseFormField.module.scss
+++ b/src/Components/Form/BaseFormField.module.scss
@@ -31,7 +31,7 @@
 
 .input,
 .selectField {
-  background-color: rgba(#fff, 0.2);
+  background-color: #52545b;
   border: 1px solid rgba(#fff, 0.5);
   border-radius: 3px;
   color: white;
@@ -48,6 +48,7 @@
 
 .selectField {
   -webkit-appearance: none;
+  -moz-appearance: none;
   appearance: none;
   padding: 0.1rem 2rem 0.1rem 0.5rem;
 }

--- a/src/Components/Form/BaseFormField.module.scss
+++ b/src/Components/Form/BaseFormField.module.scss
@@ -16,6 +16,12 @@
       order: 3;
     }
   }
+
+  &[data-form-type='select'] {
+    .fieldContainer {
+      position: relative;
+    }
+  }
 }
 
 .label {
@@ -23,18 +29,35 @@
   margin-bottom: 0.3rem;
 }
 
-.input {
+.input,
+.selectField {
   background-color: rgba(#fff, 0.2);
   border: 1px solid rgba(#fff, 0.5);
   border-radius: 3px;
   color: white;
-  margin-bottom: 0.5rem;
-  padding: 0.1rem 0.5rem;
   width: 100%;
+}
+
+.input {
+  padding: 0.1rem 0.5rem;
 
   &[type='checkbox'] {
     width: 16px;
   }
+}
+
+.selectField {
+  -webkit-appearance: none;
+  appearance: none;
+  padding: 0.1rem 2rem 0.1rem 0.5rem;
+}
+
+.selectFieldArrow {
+  pointer-events: none;
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
 .description {

--- a/src/Components/Form/SelectField.tsx
+++ b/src/Components/Form/SelectField.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 
-import { slugify } from '../../Utilities/slugify';
 import BaseFormField, { FieldProps } from './BaseFormField';
 
 type KVPair = {
@@ -11,7 +10,7 @@ type KVPair = {
 function createKeyValuePairs(options: Props['options']): KVPair[] {
   if (Array.isArray(options)) {
     return options.map((option) => ({
-      key: slugify(option),
+      key: option,
       val: option,
     }));
   }

--- a/src/Components/Form/SelectField.tsx
+++ b/src/Components/Form/SelectField.tsx
@@ -1,0 +1,80 @@
+import React, { useMemo } from 'react';
+
+import { slugify } from '../../Utilities/slugify';
+import BaseFormField, { FieldProps } from './BaseFormField';
+
+type KVPair = {
+  key: string;
+  val: string | KVPair[];
+};
+
+function createKeyValuePairs(options: Props['options']): KVPair[] {
+  if (Array.isArray(options)) {
+    return options.map((option) => ({
+      key: slugify(option),
+      val: option,
+    }));
+  }
+
+  return Object.entries(options).map(([key, value]) => {
+    return {
+      key,
+      val: typeof value === 'object' ? createKeyValuePairs(value) : value,
+    };
+  });
+}
+
+interface Props extends FieldProps<string> {
+  disabledItems?: (number | string)[];
+  formatValue?: (value: any) => string;
+  options:
+    | string[]
+    | Record<number | string, string | string[] | Record<string, string>>;
+}
+
+const SelectField = ({
+  disabledItems = [],
+  formatValue,
+  options: optionsRaw,
+  ...props
+}: Props) => {
+  const options = useMemo(() => createKeyValuePairs(optionsRaw), [optionsRaw]);
+  const isOptionDisabled = (pair: KVPair) =>
+    pair.key.trim().length === 0 || disabledItems.indexOf(pair.key) > -1;
+
+  const kvPairToJsx = (pair: KVPair) => {
+    if (Array.isArray(pair.val)) {
+      throw Error('Rendering a KVPair requires it to be simplified.');
+    }
+
+    return (
+      <option key={pair.key} value={pair.key} disabled={isOptionDisabled(pair)}>
+        {formatValue?.(pair.val) ?? pair.val}
+      </option>
+    );
+  };
+
+  return (
+    <BaseFormField
+      tag="select"
+      castStrToType={(s) => s ?? ''}
+      castTypeToStr={(s) => s}
+      {...props}
+    >
+      {options.map((option, index) => {
+        if (Array.isArray(option.val)) {
+          return (
+            <optgroup key={option.key + index} label={option.key}>
+              {option.val.map(kvPairToJsx)}
+            </optgroup>
+          );
+        }
+
+        return kvPairToJsx(option);
+      })}
+    </BaseFormField>
+  );
+};
+
+export default SelectField;
+export type { Props as ISelectFieldProps };

--- a/src/Components/Modals/TeleporterLinkEditorModal.module.scss
+++ b/src/Components/Modals/TeleporterLinkEditorModal.module.scss
@@ -1,0 +1,16 @@
+.linkList {
+  padding: 0;
+}
+
+.linkListItem {
+  display: flex;
+}
+
+.deletedItem {
+  font-style: italic;
+  text-decoration: line-through;
+}
+
+.deleteButton {
+  margin-left: auto;
+}

--- a/src/Components/Modals/TeleporterLinkEditorModal.module.scss
+++ b/src/Components/Modals/TeleporterLinkEditorModal.module.scss
@@ -14,3 +14,14 @@
 .deleteButton {
   margin-left: auto;
 }
+
+.addLinkContainer {
+  display: flex;
+  padding-right: 1rem;
+  width: 100%;
+}
+
+.teleporterSelection {
+  flex: 1;
+  margin-right: 1rem;
+}

--- a/src/Components/Modals/TeleporterLinkEditorModal.tsx
+++ b/src/Components/Modals/TeleporterLinkEditorModal.tsx
@@ -1,11 +1,94 @@
-import React from 'react';
+import { faTrash, faTrashRestore } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { useState } from 'react';
 import { useDialogState } from 'reakit';
 
+import {
+  ITeleporterLink,
+  teleporterSideLiteral,
+} from '../../Document/Obstacles/TeleporterLink';
 import {
   TeleLinkEditorOpenEvent,
   TeleLinkEditorOpenEventName,
 } from '../../Events/ITeleLinkEditorOpenEvent';
+import { classList } from '../../Utilities/cssClasses';
+import Alert, { AlertType } from '../Alert';
+import Button from '../Button';
 import ListenerModal from '../ListenerModal';
+import { Tab, TabList } from '../TabList';
+
+import alternatingStyles from '../../sass/alternatingGrid.module.scss';
+import styles from './TeleporterLinkEditorModal.module.scss';
+
+interface LinkListItemProps {
+  link: ITeleporterLink;
+  isDeleted: boolean;
+  onDelete: (uuid: string) => void;
+  onRestore: (uuid: string) => void;
+}
+
+const LinkListItem = ({
+  link,
+  isDeleted,
+  onDelete,
+  onRestore,
+}: LinkListItemProps) => {
+  const onButtonClick = () => {
+    isDeleted ? onRestore(link._uuid) : onDelete(link._uuid);
+  };
+
+  return (
+    <li
+      key={link._uuid}
+      className={classList([styles.linkListItem, alternatingStyles.listItem])}
+    >
+      <span className={classList([[styles.deletedItem, isDeleted]])}>
+        {link.to.name} ({teleporterSideLiteral(link.to.side)})
+      </span>
+      <Button
+        type={isDeleted ? 'success' : 'danger'}
+        onClick={onButtonClick}
+        className={styles.deleteButton}
+      >
+        <FontAwesomeIcon
+          fixedWidth={true}
+          icon={isDeleted ? faTrashRestore : faTrash}
+        />
+      </Button>
+    </li>
+  );
+};
+
+interface LinkEditorProps {
+  links: ITeleporterLink[];
+}
+
+const LinkEditor = ({ links }: LinkEditorProps) => {
+  const [linksToDelete, setLinksToDelete] = useState<string[]>([]);
+
+  const handleDeletion = (uuid: string) => {
+    setLinksToDelete([...linksToDelete, uuid]);
+  };
+  const handleRestore = (uuid: string) => {
+    const links = [...linksToDelete];
+    delete links[links.indexOf(uuid)];
+
+    setLinksToDelete(links);
+  };
+
+  return (
+    <ul className={classList([styles.linkList, alternatingStyles.container])}>
+      {links.map((link) => (
+        <LinkListItem
+          isDeleted={linksToDelete.indexOf(link._uuid) >= 0}
+          link={link}
+          onDelete={handleDeletion}
+          onRestore={handleRestore}
+        />
+      ))}
+    </ul>
+  );
+};
 
 const TeleporterLinkEditorModal = () => {
   const dialog = useDialogState();
@@ -18,7 +101,36 @@ const TeleporterLinkEditorModal = () => {
       hideOnClickOutside={false}
       hideOnEsc={false}
     >
-      {(eventData) => JSON.stringify(eventData)}
+      {(eventData) => {
+        if (!eventData) {
+          return (
+            <Alert type={AlertType.Danger} header="Modal Open Error">
+              This modal was opened without any event data. Please report this
+              as a bug.
+            </Alert>
+          );
+        }
+
+        const teleporter = eventData.getTeleporter();
+        const frontLinks = eventData.getFrontTeleporterLinks();
+        const backLinks = eventData.getBackTeleporterLinks();
+
+        return (
+          <>
+            <p>
+              <strong>Teleporter:</strong> {teleporter.name}
+            </p>
+            <TabList aria-label="Teleporter Sides">
+              <Tab title="Front side">
+                <LinkEditor links={frontLinks} />
+              </Tab>
+              <Tab title="Back side">
+                <LinkEditor links={backLinks} />
+              </Tab>
+            </TabList>
+          </>
+        );
+      }}
     </ListenerModal>
   );
 };

--- a/src/Components/Modals/TeleporterLinkEditorModal.tsx
+++ b/src/Components/Modals/TeleporterLinkEditorModal.tsx
@@ -1,17 +1,29 @@
-import { faTrash, faTrashRestore } from '@fortawesome/free-solid-svg-icons';
+import {
+  faPlus,
+  faSave,
+  faTrash,
+  faTrashRestore,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { useState } from 'react';
+import produce from 'immer';
+import React, { SyntheticEvent, useEffect, useMemo, useState } from 'react';
 import { useDialogState } from 'reakit';
+import { useRecoilState } from 'recoil';
 
+import { ITeleporter } from '../../Document/Obstacles/Teleporter';
 import {
   ITeleporterLink,
+  newITeleporterLink,
+  TeleporterSide,
   teleporterSideLiteral,
 } from '../../Document/Obstacles/TeleporterLink';
+import { WorldEditorHelper } from '../../Document/Utilities/WorldEditorHelper';
 import {
   TeleLinkEditorOpenEvent,
   TeleLinkEditorOpenEventName,
 } from '../../Events/ITeleLinkEditorOpenEvent';
 import { classList } from '../../Utilities/cssClasses';
+import { documentState } from '../../atoms';
 import Alert, { AlertType } from '../Alert';
 import Button from '../Button';
 import ListenerModal from '../ListenerModal';
@@ -59,13 +71,105 @@ const LinkListItem = ({
   );
 };
 
-interface LinkEditorProps {
-  links: ITeleporterLink[];
+interface LinkListItemAdderProps {
+  onAdd: (link: ITeleporterLink) => void;
+  side: TeleporterSide;
+  teleporter: ITeleporter;
+  teleporters: ITeleporter[];
 }
 
-const LinkEditor = ({ links }: LinkEditorProps) => {
+const LinkListItemAdder = ({
+  onAdd,
+  side,
+  teleporter,
+  teleporters,
+}: LinkListItemAdderProps) => {
+  const [teleporterName, setTeleporterName] = useState('');
+  const [teleSide, setTeleSide] = useState<TeleporterSide>(
+    TeleporterSide.Forward,
+  );
+
+  const handleTeleNameChange = (event: SyntheticEvent<HTMLSelectElement>) => {
+    setTeleporterName(event.currentTarget.name);
+  };
+  const handleTeleSideChange = (event: SyntheticEvent<HTMLSelectElement>) => {
+    setTeleSide(event.currentTarget.name as TeleporterSide);
+  };
+  const handleOnClick = () => {
+    onAdd({
+      ...newITeleporterLink(),
+      from: {
+        name: teleporter.name!,
+        side: side,
+      },
+      to: {
+        name: teleporterName,
+        side: teleSide,
+      },
+    });
+  };
+
+  return (
+    <li
+      className={classList([styles.linkListItem, alternatingStyles.listItem])}
+    >
+      <div>
+        <select onChange={handleTeleNameChange} value={teleporterName}>
+          {teleporters.map((tele) => (
+            <option key={tele._uuid} value={tele._uuid}>
+              {tele.name}
+            </option>
+          ))}
+        </select>
+        <select onChange={handleTeleSideChange} value={teleSide}>
+          {[
+            TeleporterSide.Forward,
+            TeleporterSide.Backward,
+            TeleporterSide.Both,
+          ].map((value) => (
+            <option key={value} value={value}>
+              {teleporterSideLiteral(value)}
+            </option>
+          ))}
+        </select>
+      </div>
+      <Button
+        type="success"
+        onClick={handleOnClick}
+        className={styles.deleteButton}
+      >
+        <FontAwesomeIcon fixedWidth={true} icon={faPlus} />
+      </Button>
+    </li>
+  );
+};
+
+interface LinkEdits {
+  add: ITeleporterLink[];
+  del: string[];
+}
+
+interface LinkEditorProps {
+  links: ITeleporterLink[];
+  onChange: (edits: LinkEdits) => void;
+  side: TeleporterSide;
+  teleporter: ITeleporter;
+  teleporters: ITeleporter[];
+}
+
+const LinkEditor = ({
+  links,
+  onChange,
+  side,
+  teleporter,
+  teleporters,
+}: LinkEditorProps) => {
+  const [linksToAdd, setLinksToAdd] = useState<ITeleporterLink[]>([]);
   const [linksToDelete, setLinksToDelete] = useState<string[]>([]);
 
+  const handleAddition = (link: ITeleporterLink) => {
+    setLinksToAdd([...linksToAdd, link]);
+  };
   const handleDeletion = (uuid: string) => {
     setLinksToDelete([...linksToDelete, uuid]);
   };
@@ -75,6 +179,13 @@ const LinkEditor = ({ links }: LinkEditorProps) => {
 
     setLinksToDelete(links);
   };
+
+  useEffect(() => {
+    onChange({
+      add: linksToAdd,
+      del: linksToDelete,
+    });
+  }, [linksToAdd, linksToDelete, onChange]);
 
   return (
     <ul className={classList([styles.linkList, alternatingStyles.container])}>
@@ -86,12 +197,34 @@ const LinkEditor = ({ links }: LinkEditorProps) => {
           onRestore={handleRestore}
         />
       ))}
+      <LinkListItemAdder
+        onAdd={handleAddition}
+        side={side}
+        teleporter={teleporter}
+        teleporters={teleporters}
+      />
     </ul>
   );
 };
 
 const TeleporterLinkEditorModal = () => {
   const dialog = useDialogState();
+  const [world, setBZWDocument] = useRecoilState(documentState);
+
+  const [frontLinkEdits, setFrontLinkEdits] = useState<LinkEdits>({
+    add: [],
+    del: [],
+  });
+  const [backLinkEdits, setBackLinkEdits] = useState<LinkEdits>({
+    add: [],
+    del: [],
+  });
+
+  const teleporters = useMemo(() => {
+    return world?._teleporters.map(
+      (uuid) => world?.children[uuid] as ITeleporter,
+    );
+  }, [world?._teleporters, world?.children]);
 
   return (
     <ListenerModal<TeleLinkEditorOpenEvent>
@@ -115,6 +248,25 @@ const TeleporterLinkEditorModal = () => {
         const frontLinks = eventData.getFrontTeleporterLinks();
         const backLinks = eventData.getBackTeleporterLinks();
 
+        const handleSave = () => {
+          const nextWorld = produce(world, (draftWorld) => {
+            if (draftWorld === null) {
+              return;
+            }
+
+            const editor = new WorldEditorHelper(draftWorld);
+            editor
+              .addLinks(frontLinkEdits.add)
+              .addLinks(backLinkEdits.add)
+              .delLinks(frontLinkEdits.del)
+              .delLinks(backLinkEdits.del)
+              .cleanUp();
+          });
+
+          setBZWDocument(nextWorld);
+          dialog.hide();
+        };
+
         return (
           <>
             <p>
@@ -122,12 +274,29 @@ const TeleporterLinkEditorModal = () => {
             </p>
             <TabList aria-label="Teleporter Sides">
               <Tab title="Front side">
-                <LinkEditor links={frontLinks} />
+                <LinkEditor
+                  links={frontLinks}
+                  onChange={setFrontLinkEdits}
+                  side={TeleporterSide.Forward}
+                  teleporter={teleporter}
+                  teleporters={teleporters ?? []}
+                />
               </Tab>
               <Tab title="Back side">
-                <LinkEditor links={backLinks} />
+                <LinkEditor
+                  links={backLinks}
+                  onChange={setBackLinkEdits}
+                  side={TeleporterSide.Backward}
+                  teleporter={teleporter}
+                  teleporters={teleporters ?? []}
+                />
               </Tab>
             </TabList>
+            <p>
+              <Button type="success" onClick={handleSave} icon={faSave}>
+                Save
+              </Button>
+            </p>
           </>
         );
       }}

--- a/src/Components/Modals/TeleporterLinkEditorModal.tsx
+++ b/src/Components/Modals/TeleporterLinkEditorModal.tsx
@@ -119,7 +119,7 @@ const LinkListItemAdder = ({
   };
 
   return (
-    <li
+    <div
       className={classList([styles.linkListItem, alternatingStyles.listItem])}
     >
       <div>
@@ -149,7 +149,7 @@ const LinkListItemAdder = ({
       >
         <FontAwesomeIcon fixedWidth={true} icon={faPlus} />
       </Button>
-    </li>
+    </div>
   );
 };
 
@@ -208,16 +208,26 @@ const LinkEditor = ({ links, onChange, side, teleporter }: LinkEditorProps) => {
     ));
 
   return (
-    <ul className={classList([styles.linkList, alternatingStyles.container])}>
-      {renderLinks(links, '')}
-      {renderLinks(linksToAdd, '-new')}
+    <div>
+      {links.length === 0 && linksToAdd.length === 0 && (
+        <Alert type={AlertType.Warning} header="No Links Associated">
+          This teleporter does not have any links associated with it on the{' '}
+          {teleporterSideLiteral(side)} side. This means a tank will simply
+          drive through this teleporter and not be teleported anywhere.
+        </Alert>
+      )}
+
+      <ul className={classList([styles.linkList, alternatingStyles.container])}>
+        {renderLinks(links, '')}
+        {renderLinks(linksToAdd, '-new')}
+      </ul>
 
       <LinkListItemAdder
         onAdd={handleAddition}
         side={side}
         teleporter={teleporter}
       />
-    </ul>
+    </div>
   );
 };
 

--- a/src/Components/Modals/TeleporterLinkEditorModal.tsx
+++ b/src/Components/Modals/TeleporterLinkEditorModal.tsx
@@ -7,7 +7,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import produce from 'immer';
 import { nanoid } from 'nanoid';
-import React, { SyntheticEvent, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDialogState } from 'reakit';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
@@ -27,6 +27,7 @@ import { classList } from '../../Utilities/cssClasses';
 import { documentState } from '../../atoms';
 import Alert, { AlertType } from '../Alert';
 import Button from '../Button';
+import SelectField from '../Form/SelectField';
 import ListenerModal from '../ListenerModal';
 import { Tab, TabList } from '../TabList';
 
@@ -94,14 +95,12 @@ const LinkListItemAdder = ({
     TeleporterSide.Forward,
   );
 
-  const handleTeleNameChange = (event: SyntheticEvent<HTMLSelectElement>) => {
-    const uuid = event.currentTarget.value;
-
-    setTeleName((world?.children[uuid] as ITeleporter).name!);
-    setTeleUUID(uuid);
+  const handleTeleNameChange = (teleUUID: string) => {
+    setTeleName((world?.children[teleUUID] as ITeleporter).name!);
+    setTeleUUID(teleUUID);
   };
-  const handleTeleSideChange = (event: SyntheticEvent<HTMLSelectElement>) => {
-    setTeleSide(event.currentTarget.value as TeleporterSide);
+  const handleTeleSideChange = (value: string) => {
+    setTeleSide(value as TeleporterSide);
   };
   const handleOnClick = () => {
     onAdd({
@@ -122,25 +121,32 @@ const LinkListItemAdder = ({
     <div
       className={classList([styles.linkListItem, alternatingStyles.listItem])}
     >
-      <div>
-        <select onChange={handleTeleNameChange} value={teleUUID}>
-          {teleUUIDs.map((uuid) => (
-            <option key={uuid} value={uuid}>
-              {(world?.children[uuid] as ITeleporter).name}
-            </option>
-          ))}
-        </select>
-        <select onChange={handleTeleSideChange} value={teleSide}>
-          {[
+      <div className={styles.addLinkContainer}>
+        <SelectField
+          className={styles.teleporterSelection}
+          options={Object.fromEntries(
+            teleUUIDs.map((uuid) => [
+              uuid,
+              (world?.children[uuid] as ITeleporter).name!,
+            ]),
+          )}
+          hideLabel={true}
+          label="Teleporter"
+          onChange={handleTeleNameChange}
+          value={teleUUID}
+        />
+        <SelectField
+          options={[
             TeleporterSide.Forward,
             TeleporterSide.Backward,
             TeleporterSide.Both,
-          ].map((value) => (
-            <option key={value} value={value}>
-              {teleporterSideLiteral(value)}
-            </option>
-          ))}
-        </select>
+          ]}
+          formatValue={teleporterSideLiteral}
+          hideLabel={true}
+          label="Teleporter Side"
+          onChange={handleTeleSideChange}
+          value={teleSide}
+        />
       </div>
       <Button
         type="success"

--- a/src/Components/Modals/TeleporterLinkEditorModal.tsx
+++ b/src/Components/Modals/TeleporterLinkEditorModal.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useDialogState } from 'reakit';
+
+import {
+  TeleLinkEditorOpenEvent,
+  TeleLinkEditorOpenEventName,
+} from '../../Events/ITeleLinkEditorOpenEvent';
+import ListenerModal from '../ListenerModal';
+
+const TeleporterLinkEditorModal = () => {
+  const dialog = useDialogState();
+
+  return (
+    <ListenerModal<TeleLinkEditorOpenEvent>
+      dialog={dialog}
+      event={TeleLinkEditorOpenEventName}
+      title="Teleporter Link Editor"
+      hideOnClickOutside={false}
+      hideOnEsc={false}
+    >
+      {(eventData) => JSON.stringify(eventData)}
+    </ListenerModal>
+  );
+};
+
+export default TeleporterLinkEditorModal;

--- a/src/Components/Modals/TeleporterLinkEditorModal.tsx
+++ b/src/Components/Modals/TeleporterLinkEditorModal.tsx
@@ -189,7 +189,7 @@ const LinkEditor = ({
 
   return (
     <ul className={classList([styles.linkList, alternatingStyles.container])}>
-      {links.map((link) => (
+      {[...links, ...linksToAdd].map((link) => (
         <LinkListItem
           isDeleted={linksToDelete.indexOf(link._uuid) >= 0}
           link={link}

--- a/src/Components/Panels/Inventory/LinkSummary.tsx
+++ b/src/Components/Panels/Inventory/LinkSummary.tsx
@@ -4,10 +4,15 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { IBaseObject } from '../../../Document/Obstacles/BaseObject';
 import { ITeleporter } from '../../../Document/Obstacles/Teleporter';
-import { TeleporterSide } from '../../../Document/Obstacles/TeleporterLink';
+import {
+  ITeleporterLink,
+  TeleporterSide,
+} from '../../../Document/Obstacles/TeleporterLink';
+import { documentState } from '../../../atoms';
 
 import styles from './ObstacleSummary.module.scss';
 
@@ -16,17 +21,25 @@ interface Props {
 }
 
 const LinkSummary = ({ object }: Props) => {
+  const world = useRecoilValue(documentState);
+
   const tele = object as ITeleporter;
-  const frontLinks = tele._links.filter(
-    (link) =>
+  const frontLinks = tele._links.filter((uuid) => {
+    const link = world?.children[uuid] as ITeleporterLink;
+
+    return (
       link.from.side !== TeleporterSide.Backward ||
-      link.to.side !== TeleporterSide.Backward,
-  );
-  const backLinks = tele._links.filter(
-    (link) =>
+      link.to.side !== TeleporterSide.Backward
+    );
+  });
+  const backLinks = tele._links.filter((uuid) => {
+    const link = world?.children[uuid] as ITeleporterLink;
+
+    return (
       link.from.side !== TeleporterSide.Forward ||
-      link.to.side !== TeleporterSide.Forward,
-  );
+      link.to.side !== TeleporterSide.Forward
+    );
+  });
 
   return (
     <div>
@@ -36,7 +49,8 @@ const LinkSummary = ({ object }: Props) => {
           <div className={styles.links} key={side}>
             <div>{side}</div>
             <ul>
-              {links.map((link, i) => {
+              {links.map((uuid, i) => {
+                const link = world?.children[uuid] as ITeleporterLink;
                 const isFromTele = link.from.name === tele.name;
                 const teleRef = isFromTele ? link.to : link.from;
                 const icon = isFromTele

--- a/src/Components/Panels/Inventory/ObstacleSummary.tsx
+++ b/src/Components/Panels/Inventory/ObstacleSummary.tsx
@@ -12,10 +12,10 @@ import React, {
 } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
-import { INameable } from '../../../Document/Attributes/INameable';
 import { IBase } from '../../../Document/Obstacles/Base';
 import { IBaseObject } from '../../../Document/Obstacles/BaseObject';
 import { ITankModelObjectType } from '../../../Document/Obstacles/TankModel';
+import { WorldEditorHelper } from '../../../Document/Utilities/WorldEditorHelper';
 import { classList } from '../../../Utilities/cssClasses';
 import keyboard from '../../../Utilities/keyboard';
 import { documentState, selectionState } from '../../../atoms';
@@ -140,9 +140,12 @@ const ObstacleSummary = forwardRef<HTMLDivElement, Props>(
 
     const saveName = () => {
       const nextWorld = produce(world, (draftWorld) => {
-        const obstacle: INameable = draftWorld!.children[selectedUUID!] as any;
+        if (!draftWorld || !selectedUUID) {
+          return;
+        }
 
-        obstacle.name = nameEdit;
+        const editor = new WorldEditorHelper(draftWorld);
+        editor.renameObstacle(selectedUUID, nameEdit);
       });
 
       setBZWDocument(nextWorld);

--- a/src/Components/Panels/Menubar/ObjectMenu/AddObstacleMenuItem.tsx
+++ b/src/Components/Panels/Menubar/ObjectMenu/AddObstacleMenuItem.tsx
@@ -7,6 +7,7 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { IBaseObject } from '../../../../Document/Obstacles/BaseObject';
 import { IWorld } from '../../../../Document/Obstacles/World';
+import { WorldEditorHelper } from '../../../../Document/Utilities/WorldEditorHelper';
 import { documentState, selectionState } from '../../../../atoms';
 import MenuItem, { IMenuItemProps } from '../MenuItem';
 
@@ -23,12 +24,13 @@ const AddObstacleMenuItem = ({ factory, icon, object, ...menu }: Props) => {
   const handleOnTriggerMenuItem = () => {
     const uuid = nanoid(7);
 
-    const box = factory();
-    box._uuid = uuid;
-    box.name = `New ${object}`;
+    const obstacle = factory();
+    obstacle._uuid = uuid;
+    obstacle.name = `New ${object}`;
 
     const world = produce(document, (draftWorld: IWorld) => {
-      draftWorld.children[uuid] = box;
+      const editor = new WorldEditorHelper(draftWorld);
+      editor.addObstacle(obstacle);
     });
 
     setSelection(uuid);

--- a/src/Components/Panels/Menubar/ObjectMenu/DeleteSelectedMenuItem.tsx
+++ b/src/Components/Panels/Menubar/ObjectMenu/DeleteSelectedMenuItem.tsx
@@ -5,6 +5,7 @@ import { MenuStateReturn } from 'reakit';
 import { useRecoilState } from 'recoil';
 
 import { IWorld } from '../../../../Document/Obstacles/World';
+import { WorldEditorHelper } from '../../../../Document/Utilities/WorldEditorHelper';
 import { documentState, selectionState } from '../../../../atoms';
 import MenuItem from '../MenuItem';
 
@@ -19,8 +20,10 @@ const DeleteSelectedMenuItem = ({ ...menu }: Props) => {
         return;
       }
 
+      const editor = new WorldEditorHelper(draftWorld);
+      editor.delObstacle(selected);
+
       setSelected(null);
-      delete draftWorld.children[selected];
     });
 
     setDocument(world);

--- a/src/Components/Panels/Toolbox/TeleporterControl.module.scss
+++ b/src/Components/Panels/Toolbox/TeleporterControl.module.scss
@@ -1,0 +1,33 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  margin-bottom: 0.5rem;
+}
+
+.heading {
+  font-size: 1rem;
+  font-weight: bold;
+  margin-bottom: 0;
+}
+
+.editButton {
+  font-size: 0.8rem;
+  margin-left: auto;
+}
+
+.linkListHeader {
+  font-size: 0.8rem;
+  font-weight: bold;
+}
+
+.teleLinks {
+  padding-left: 1.5rem;
+}
+
+.teleLink {
+  white-space: nowrap;
+}

--- a/src/Components/Panels/Toolbox/TeleporterControl.module.scss
+++ b/src/Components/Panels/Toolbox/TeleporterControl.module.scss
@@ -1,6 +1,7 @@
 .wrapper {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .header {
@@ -20,6 +21,11 @@
   margin-left: auto;
 }
 
+.linkListContainer {
+  height: 100%;
+  overflow: hidden;
+}
+
 .linkListHeader {
   font-size: 0.8rem;
   font-weight: bold;
@@ -27,6 +33,7 @@
 
 .linkList {
   min-width: 300px;
+  overflow: hidden;
 }
 
 .noLinks {
@@ -36,6 +43,9 @@
 }
 
 .teleLinks {
+  height: 100%;
+  margin-bottom: 0;
+  overflow: auto;
   padding-left: 1.5rem;
 }
 

--- a/src/Components/Panels/Toolbox/TeleporterControl.module.scss
+++ b/src/Components/Panels/Toolbox/TeleporterControl.module.scss
@@ -12,6 +12,7 @@
   font-size: 1rem;
   font-weight: bold;
   margin-bottom: 0;
+  margin-right: 1rem;
 }
 
 .editButton {
@@ -22,6 +23,16 @@
 .linkListHeader {
   font-size: 0.8rem;
   font-weight: bold;
+}
+
+.linkList {
+  min-width: 300px;
+}
+
+.noLinks {
+  color: rgba(#fff, 0.6);
+  font-size: 0.9rem;
+  font-style: italic;
 }
 
 .teleLinks {

--- a/src/Components/Panels/Toolbox/TeleporterControl.tsx
+++ b/src/Components/Panels/Toolbox/TeleporterControl.tsx
@@ -12,6 +12,7 @@ import {
   TeleLinkEditorOpenEventName,
 } from '../../../Events/ITeleLinkEditorOpenEvent';
 import eventBus from '../../../Utilities/EventBus';
+import { classList } from '../../../Utilities/cssClasses';
 import { documentState } from '../../../atoms';
 import Button from '../../Button';
 
@@ -31,13 +32,18 @@ const LinkRenderer = ({ title, links: teleLinks }: LinkRendererProps) => {
   return (
     <div className="col-6">
       <h3 className={styles.linkListHeader}>{title}</h3>
-      <ul className={styles.teleLinks}>
-        {links.map((link) => (
-          <li key={link._uuid} className={styles.teleLink}>
-            {link.to.name} ({teleporterSideLiteral(link.to.side)})
-          </li>
-        ))}
-      </ul>
+
+      {links.length === 0 ? (
+        <span className={styles.noLinks}>No Links</span>
+      ) : (
+        <ul className={styles.teleLinks}>
+          {links.map((link) => (
+            <li key={link._uuid} className={styles.teleLink}>
+              {link.to.name} ({teleporterSideLiteral(link.to.side)})
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };
@@ -89,7 +95,7 @@ const TeleporterControl = ({ data }: Props) => {
             Edit
           </Button>
         </div>
-        <div className="row">
+        <div className={classList([styles.linkList, 'row'])}>
           <LinkRenderer title="Front" links={frontLinks} />
           <LinkRenderer title="Back" links={backLinks} />
         </div>

--- a/src/Components/Panels/Toolbox/TeleporterControl.tsx
+++ b/src/Components/Panels/Toolbox/TeleporterControl.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { ITeleporter } from '../../../Document/Obstacles/Teleporter';
 import {
@@ -11,6 +12,7 @@ import {
   TeleLinkEditorOpenEventName,
 } from '../../../Events/ITeleLinkEditorOpenEvent';
 import eventBus from '../../../Utilities/EventBus';
+import { documentState } from '../../../atoms';
 import Button from '../../Button';
 
 import styles from './TeleporterControl.module.scss';
@@ -46,11 +48,14 @@ interface Props {
 }
 
 const TeleporterControl = ({ data }: Props) => {
+  const world = useRecoilValue(documentState);
   const [frontLinks, backLinks] = useMemo(() => {
     const front: ITeleporterLink[] = [],
       back: ITeleporterLink[] = [];
 
-    for (const link of data._links) {
+    for (const linkUUID of data._links) {
+      const link = world?.children[linkUUID] as ITeleporterLink;
+
       if (link.from.name !== data.name) {
         continue;
       }
@@ -66,7 +71,7 @@ const TeleporterControl = ({ data }: Props) => {
     }
 
     return [front, back];
-  }, [data]);
+  }, [data._links, data.name, world?.children]);
   const handleOpenEditor = () => {
     const eventData = new TeleLinkEditorOpenEvent(data, frontLinks, backLinks);
     eventBus.dispatch(TeleLinkEditorOpenEventName, eventData);

--- a/src/Components/Panels/Toolbox/TeleporterControl.tsx
+++ b/src/Components/Panels/Toolbox/TeleporterControl.tsx
@@ -44,7 +44,6 @@ const LinkRenderer = ({ title, links: teleLinks }: LinkRendererProps) => {
 
 interface Props {
   data: ITeleporter;
-  onChange: (changes: ITeleporter) => void;
 }
 
 const TeleporterControl = ({ data }: Props) => {

--- a/src/Components/Panels/Toolbox/TeleporterControl.tsx
+++ b/src/Components/Panels/Toolbox/TeleporterControl.tsx
@@ -49,32 +49,32 @@ interface Props {
 
 const TeleporterControl = ({ data }: Props) => {
   const world = useRecoilValue(documentState);
-  const [frontLinks, backLinks] = useMemo(() => {
-    const front: ITeleporterLink[] = [],
-      back: ITeleporterLink[] = [];
 
-    for (const linkUUID of data._links) {
-      const link = world?.children[linkUUID] as ITeleporterLink;
+  const frontLinks: ITeleporterLink[] = [];
+  const backLinks: ITeleporterLink[] = [];
 
-      if (link === undefined || link.from.name !== data.name) {
-        continue;
-      }
+  for (const linkUUID of data._links) {
+    const link = world?.children[linkUUID] as ITeleporterLink;
 
-      if (link.from.side === TeleporterSide.Forward) {
-        front.push(link);
-      } else if (link.from.side === TeleporterSide.Backward) {
-        back.push(link);
-      } else {
-        front.push(link);
-        back.push(link);
-      }
+    if (link === undefined || link.from.name !== data.name) {
+      continue;
     }
 
-    return [front, back];
-  }, [data._links, data.name, world?.children]);
+    if (link.from.side === TeleporterSide.Forward) {
+      frontLinks.push(link);
+    } else if (link.from.side === TeleporterSide.Backward) {
+      backLinks.push(link);
+    } else {
+      frontLinks.push(link);
+      backLinks.push(link);
+    }
+  }
+
   const handleOpenEditor = () => {
-    const eventData = new TeleLinkEditorOpenEvent(data, frontLinks, backLinks);
-    eventBus.dispatch(TeleLinkEditorOpenEventName, eventData);
+    eventBus.dispatch(
+      TeleLinkEditorOpenEventName,
+      new TeleLinkEditorOpenEvent(data, frontLinks, backLinks),
+    );
   };
 
   return (

--- a/src/Components/Panels/Toolbox/TeleporterControl.tsx
+++ b/src/Components/Panels/Toolbox/TeleporterControl.tsx
@@ -47,8 +47,8 @@ interface Props {
 
 const TeleporterControl = ({ data }: Props) => {
   const [frontLinks, backLinks] = useMemo(() => {
-    const front = [];
-    const back = [];
+    const front: ITeleporterLink[] = [],
+      back: ITeleporterLink[] = [];
 
     for (const link of data._links) {
       if (link.from.name !== data.name) {
@@ -68,7 +68,7 @@ const TeleporterControl = ({ data }: Props) => {
     return [front, back];
   }, [data]);
   const handleOpenEditor = () => {
-    const eventData = new TeleLinkEditorOpenEvent(data);
+    const eventData = new TeleLinkEditorOpenEvent(data, frontLinks, backLinks);
     eventBus.dispatch(TeleLinkEditorOpenEventName, eventData);
   };
 

--- a/src/Components/Panels/Toolbox/TeleporterControl.tsx
+++ b/src/Components/Panels/Toolbox/TeleporterControl.tsx
@@ -56,7 +56,7 @@ const TeleporterControl = ({ data }: Props) => {
     for (const linkUUID of data._links) {
       const link = world?.children[linkUUID] as ITeleporterLink;
 
-      if (link.from.name !== data.name) {
+      if (link === undefined || link.from.name !== data.name) {
         continue;
       }
 

--- a/src/Components/Panels/Toolbox/TeleporterControl.tsx
+++ b/src/Components/Panels/Toolbox/TeleporterControl.tsx
@@ -1,0 +1,98 @@
+import React, { useMemo } from 'react';
+
+import { ITeleporter } from '../../../Document/Obstacles/Teleporter';
+import {
+  ITeleporterLink,
+  TeleporterSide,
+  teleporterSideLiteral,
+} from '../../../Document/Obstacles/TeleporterLink';
+import {
+  TeleLinkEditorOpenEvent,
+  TeleLinkEditorOpenEventName,
+} from '../../../Events/ITeleLinkEditorOpenEvent';
+import eventBus from '../../../Utilities/EventBus';
+import Button from '../../Button';
+
+import styles from './TeleporterControl.module.scss';
+
+interface LinkRendererProps {
+  title: string;
+  links: ITeleporterLink[];
+}
+
+const LinkRenderer = ({ title, links: teleLinks }: LinkRendererProps) => {
+  const links = useMemo(
+    () => teleLinks.sort((a, b) => a.to.name.localeCompare(b.to.name)),
+    [teleLinks],
+  );
+
+  return (
+    <div className="col-6">
+      <h3 className={styles.linkListHeader}>{title}</h3>
+      <ul className={styles.teleLinks}>
+        {links.map((link) => (
+          <li key={link._uuid} className={styles.teleLink}>
+            {link.to.name} ({teleporterSideLiteral(link.to.side)})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+interface Props {
+  data: ITeleporter;
+  onChange: (changes: ITeleporter) => void;
+}
+
+const TeleporterControl = ({ data }: Props) => {
+  const [frontLinks, backLinks] = useMemo(() => {
+    const front = [];
+    const back = [];
+
+    for (const link of data._links) {
+      if (link.from.name !== data.name) {
+        continue;
+      }
+
+      if (link.from.side === TeleporterSide.Forward) {
+        front.push(link);
+      } else if (link.from.side === TeleporterSide.Backward) {
+        back.push(link);
+      } else {
+        front.push(link);
+        back.push(link);
+      }
+    }
+
+    return [front, back];
+  }, [data]);
+  const handleOpenEditor = () => {
+    const eventData = new TeleLinkEditorOpenEvent(data);
+    eventBus.dispatch(TeleLinkEditorOpenEventName, eventData);
+  };
+
+  return (
+    <section>
+      <div className={styles.wrapper}>
+        <div className={styles.header}>
+          <h2 className={styles.heading}>Teleporter Links</h2>
+          <Button
+            type="info"
+            className={styles.editButton}
+            onClick={handleOpenEditor}
+          >
+            Edit
+          </Button>
+        </div>
+        <div className="row">
+          <LinkRenderer title="Front" links={frontLinks} />
+          <LinkRenderer title="Back" links={backLinks} />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TeleporterControl;
+export type { Props as ITeleporterControlProps };

--- a/src/Components/Panels/Toolbox/TeleporterControl.tsx
+++ b/src/Components/Panels/Toolbox/TeleporterControl.tsx
@@ -30,7 +30,7 @@ const LinkRenderer = ({ title, links: teleLinks }: LinkRendererProps) => {
   );
 
   return (
-    <div className="col-6">
+    <div className={classList([styles.linkListContainer, 'col-6'])}>
       <h3 className={styles.linkListHeader}>{title}</h3>
 
       {links.length === 0 ? (

--- a/src/Components/Panels/ToolboxPanel.module.scss
+++ b/src/Components/Panels/ToolboxPanel.module.scss
@@ -19,6 +19,7 @@
     border: 1px solid rgba(#fff, 0.3);
     display: flex;
     margin-right: 0.5rem;
+    overflow: hidden;
     padding: 1rem 1.25rem;
 
     &:last-child {

--- a/src/Components/Panels/ToolboxPanel.tsx
+++ b/src/Components/Panels/ToolboxPanel.tsx
@@ -132,10 +132,7 @@ const ToolboxPanel = () => {
         <BaseControl data={selection as IBase} onChange={handleBaseOnChange} />
       )}
       {selection && selection._objectType === 'teleporter' && (
-        <TeleporterControl
-          data={selection as ITeleporter}
-          onChange={() => {}}
-        />
+        <TeleporterControl data={selection as ITeleporter} />
       )}
     </div>
   );

--- a/src/Components/Panels/ToolboxPanel.tsx
+++ b/src/Components/Panels/ToolboxPanel.tsx
@@ -10,6 +10,7 @@ import { implementsISizeable } from '../../Document/Attributes/ISizeable';
 import { IBase } from '../../Document/Obstacles/Base';
 import { IBaseObject } from '../../Document/Obstacles/BaseObject';
 import { IPyramid } from '../../Document/Obstacles/Pyramid';
+import { ITeleporter } from '../../Document/Obstacles/Teleporter';
 import { documentState, selectionState } from '../../atoms';
 import AlterableControl, {
   IAlterableControlDataType,
@@ -18,6 +19,7 @@ import AlterableControl, {
 import BaseControl from './Toolbox/BaseControl';
 import PassabilityControl from './Toolbox/PassabilityControl';
 import PyramidControl from './Toolbox/PyramidControl';
+import TeleporterControl from './Toolbox/TeleporterControl';
 
 import styles from './ToolboxPanel.module.scss';
 
@@ -128,6 +130,12 @@ const ToolboxPanel = () => {
       )}
       {selection && selection._objectType === 'base' && (
         <BaseControl data={selection as IBase} onChange={handleBaseOnChange} />
+      )}
+      {selection && selection._objectType === 'teleporter' && (
+        <TeleporterControl
+          data={selection as ITeleporter}
+          onChange={() => {}}
+        />
       )}
     </div>
   );

--- a/src/Components/TabList.module.scss
+++ b/src/Components/TabList.module.scss
@@ -1,0 +1,35 @@
+@import '../sass/variables';
+
+.tabList {
+  border-bottom: 1px solid white;
+}
+
+.tab {
+  background-color: transparent;
+  border: 1px solid transparent;
+  border-bottom: 0;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+  color: white;
+  padding: 0.25rem 0.75rem;
+  position: relative;
+
+  &[aria-selected='true'] {
+    border-color: white;
+    border-bottom-color: transparent;
+
+    &::after {
+      background-color: $color-grey-light;
+      bottom: -1px;
+      content: '';
+      height: 1px;
+      left: 0;
+      position: absolute;
+      width: 100%;
+    }
+  }
+}
+
+.panel {
+  padding: 1rem;
+}

--- a/src/Components/TabList.tsx
+++ b/src/Components/TabList.tsx
@@ -1,0 +1,44 @@
+import React, { ReactElement, ReactNode } from 'react';
+import {
+  Tab as BaseTab,
+  TabList as BaseTabList,
+  TabPanel as BaseTabPanel,
+  useTabState,
+} from 'reakit';
+
+import styles from './TabList.module.scss';
+
+interface TabProps {
+  title: string;
+  children: ReactNode;
+}
+
+const Tab = ({ children }: TabProps) => <>{children}</>;
+
+interface TabListProps {
+  children: ReactElement<TabProps> | ReactElement<TabProps>[];
+}
+
+const TabList = ({ children, ...props }: TabListProps) => {
+  const tab = useTabState();
+
+  return (
+    <>
+      <BaseTabList {...tab} {...props} className={styles.tabList}>
+        {React.Children.map(children, (child) => (
+          <BaseTab {...tab} className={styles.tab}>
+            {child.props.title}
+          </BaseTab>
+        ))}
+      </BaseTabList>
+      {React.Children.map(children, (child) => (
+        <BaseTabPanel {...tab} className={styles.panel}>
+          {child.props.children}
+        </BaseTabPanel>
+      ))}
+    </>
+  );
+};
+
+export { Tab, TabList };
+export type { TabProps as ITabProps, TabListProps as ITabListProps };

--- a/src/Document/Obstacles/Teleporter.ts
+++ b/src/Document/Obstacles/Teleporter.ts
@@ -3,7 +3,6 @@ import { IPositionable } from '../Attributes/IPositionable';
 import { ISizeable } from '../Attributes/ISizeable';
 import { bzwFloat, bzwVector3F } from '../attributeParsers';
 import { IBaseObject, newIBaseObject } from './BaseObject';
-import { ITeleporterLink } from './TeleporterLink';
 
 export const TeleporterProperties = {
   position: bzwVector3F,
@@ -18,7 +17,7 @@ export interface ITeleporter
     IPositionable,
     ISizeable {
   border: number;
-  _links: ITeleporterLink[];
+  _links: string[];
 }
 
 export function newITeleporter(): ITeleporter {

--- a/src/Document/Obstacles/TeleporterLink.ts
+++ b/src/Document/Obstacles/TeleporterLink.ts
@@ -31,3 +31,16 @@ export function newITeleporterLink(): ITeleporterLink {
     to: { name: '', side: TeleporterSide.Both },
   };
 }
+
+export function teleporterSideLiteral(side: TeleporterSide): string {
+  switch (side) {
+    case TeleporterSide.Backward:
+      return 'Back';
+
+    case TeleporterSide.Forward:
+      return 'Front';
+
+    case TeleporterSide.Both:
+      return 'Both';
+  }
+}

--- a/src/Document/Obstacles/World.ts
+++ b/src/Document/Obstacles/World.ts
@@ -2,7 +2,6 @@ import { INameable } from '../Attributes/INameable';
 import { bzwBool, bzwFloat, bzwString } from '../attributeParsers';
 import { IBaseObject, newIBaseObject } from './BaseObject';
 import { IOptions, newIOptions } from './Option';
-import { ITeleporter } from './Teleporter';
 
 export const WorldProperties = {
   name: bzwString,
@@ -14,7 +13,7 @@ export const WorldProperties = {
 
 export interface IWorld extends IBaseObject, INameable {
   _options: IOptions;
-  _teleporters: ITeleporter[];
+  _teleporters: string[];
   size: number;
   flagheight?: number;
   nowalls: boolean;

--- a/src/Document/Utilities/WorldEditorHelper.ts
+++ b/src/Document/Utilities/WorldEditorHelper.ts
@@ -1,0 +1,105 @@
+import { ITeleporter } from '../Obstacles/Teleporter';
+import { ITeleporterLink } from '../Obstacles/TeleporterLink';
+import { IWorld } from '../Obstacles/World';
+
+interface LinkCache {
+  owner: string;
+  index: number;
+}
+
+export class WorldEditorHelper {
+  private areLinksCached: boolean = false;
+  private linkCache: Record<string, LinkCache> = {};
+  private teleCache: Record<string, string> = {};
+
+  constructor(private world: IWorld) {}
+
+  addLink(link: ITeleporterLink): this {
+    this.cacheLinks();
+
+    const teleName = link.from.name;
+    const teleUUID = this.teleCache[teleName];
+
+    if (!teleUUID) {
+      throw Error(`Invalid teleporter name: ${teleName}`);
+    }
+
+    const teleporter = this.world.children[teleUUID] as ITeleporter;
+
+    if (!teleporter) {
+      throw Error(`Invalid teleporter UUID: ${teleUUID}`);
+    }
+
+    this.world.children[link._uuid] = link;
+    teleporter._links.push(link._uuid);
+
+    return this;
+  }
+
+  addLinks(links: ITeleporterLink[]): this {
+    links.forEach(this.addLink);
+
+    return this;
+  }
+
+  delLink(linkUUID: string): this {
+    this.cacheLinks();
+    this.delLinks([linkUUID]);
+
+    return this;
+  }
+
+  delLinks(linkUUIDs: string[]): this {
+    this.cacheLinks();
+
+    linkUUIDs.forEach((uuid) => {
+      delete this.world.children[uuid];
+
+      const mapCache = this.linkCache[uuid];
+      this.world.children[mapCache.owner]._links[mapCache.index] = null;
+    });
+
+    return this;
+  }
+
+  cleanUp(): void {
+    this.world._teleporters.forEach((teleUUID) => {
+      const teleporter = this.world.children[teleUUID] as ITeleporter;
+      teleporter._links = teleporter._links.filter(Boolean);
+
+      this.world.children[teleUUID] = teleporter;
+    });
+
+    this.areLinksCached = false;
+  }
+
+  private cacheLinks(): void {
+    if (this.areLinksCached) {
+      return;
+    }
+
+    this.world._teleporters.forEach((teleUUID) => {
+      const teleporter = this.world.children[teleUUID] as ITeleporter;
+
+      if (!teleporter) {
+        return;
+      }
+
+      this.teleCache[teleporter.name!] = teleUUID;
+      teleporter._links.forEach((uuid, index) => {
+        const link = this.world.children[uuid] as ITeleporterLink;
+
+        if (teleUUID !== this.teleCache[link.from.name]) {
+          return;
+        }
+
+        this.linkCache[uuid] = {
+          owner: teleUUID,
+          index: index,
+        };
+      });
+    });
+
+    this.areLinksCached = true;
+  }
+}

--- a/src/Document/Utilities/WorldEditorHelper.ts
+++ b/src/Document/Utilities/WorldEditorHelper.ts
@@ -14,7 +14,7 @@ export class WorldEditorHelper {
 
   constructor(private world: IWorld) {}
 
-  addLink(link: ITeleporterLink): this {
+  addLink = (link: ITeleporterLink): this => {
     this.cacheLinks();
 
     const teleName = link.from.name;
@@ -34,35 +34,37 @@ export class WorldEditorHelper {
     teleporter._links.push(link._uuid);
 
     return this;
-  }
+  };
 
-  addLinks(links: ITeleporterLink[]): this {
+  addLinks = (links: ITeleporterLink[]): this => {
     links.forEach(this.addLink);
 
     return this;
-  }
+  };
 
-  delLink(linkUUID: string): this {
-    this.cacheLinks();
+  delLink = (linkUUID: string): this => {
     this.delLinks([linkUUID]);
 
     return this;
-  }
+  };
 
-  delLinks(linkUUIDs: string[]): this {
+  delLinks = (linkUUIDs: string[]): this => {
     this.cacheLinks();
 
     linkUUIDs.forEach((uuid) => {
       delete this.world.children[uuid];
+      const linkRef = this.linkCache[uuid];
 
-      const mapCache = this.linkCache[uuid];
-      this.world.children[mapCache.owner]._links[mapCache.index] = null;
+      // Only delete link references if a Link with said UUID exists
+      if (linkRef) {
+        this.world.children[linkRef.owner]._links[linkRef.index] = null;
+      }
     });
 
     return this;
-  }
+  };
 
-  cleanUp(): void {
+  cleanUp = (): void => {
     this.world._teleporters.forEach((teleUUID) => {
       const teleporter = this.world.children[teleUUID] as ITeleporter;
       teleporter._links = teleporter._links.filter(Boolean);
@@ -70,10 +72,16 @@ export class WorldEditorHelper {
       this.world.children[teleUUID] = teleporter;
     });
 
-    this.areLinksCached = false;
-  }
+    this.clearTeleCache();
+  };
 
-  private cacheLinks(): void {
+  clearTeleCache = (): void => {
+    this.areLinksCached = false;
+    this.linkCache = {};
+    this.teleCache = {};
+  };
+
+  private cacheLinks = (): void => {
     if (this.areLinksCached) {
       return;
     }
@@ -101,5 +109,5 @@ export class WorldEditorHelper {
     });
 
     this.areLinksCached = true;
-  }
+  };
 }

--- a/src/Document/Utilities/__tests__/WorldEditorHelper.ts
+++ b/src/Document/Utilities/__tests__/WorldEditorHelper.ts
@@ -10,87 +10,156 @@ import { parseBZWDocument } from '../../parseBZWDocument';
 import { WorldEditorHelper } from '../WorldEditorHelper';
 
 describe('BZW Editor Helper', () => {
-  it('should add teleporter links', () => {
-    const world = parseBZWDocument(dedent`
-    teleporter tele1
-      pos 0 0 0
-      size 5 5 5
-    end
+  describe('Editing Teleporter and Links', () => {
+    describe('Link Edits', () => {
+      it('should add teleporter links', () => {
+        const world = parseBZWDocument(dedent`
+          teleporter tele1
+            pos 0 0 0
+            size 5 5 5
+          end
 
-    teleporter tele2
-      pos 0 0 0
-      size 5 5 5
-    end
+          teleporter tele2
+            pos 0 0 0
+            size 5 5 5
+          end
 
-    link
-      from tele1:f
-      to tele2:f
-    end
-    `);
-    const link = {
-      ...newITeleporterLink(),
-      _uuid: nanoid(),
-      from: {
-        name: 'tele1',
-        side: TeleporterSide.Backward,
-      },
-      to: {
-        name: 'tele2',
-        side: TeleporterSide.Backward,
-      },
-    };
-    const helper = new WorldEditorHelper(world);
-    helper.addLink(link).cleanUp();
+          link
+            from tele1:f
+            to tele2:f
+          end
+        `);
+        const link = {
+          ...newITeleporterLink(),
+          _uuid: nanoid(),
+          from: {
+            name: 'tele1',
+            side: TeleporterSide.Backward,
+          },
+          to: {
+            name: 'tele2',
+            side: TeleporterSide.Backward,
+          },
+        };
+        const helper = new WorldEditorHelper(world);
+        helper.addLink(link).cleanUp();
 
-    const teleporter = world.children[world._teleporters[0]] as ITeleporter;
+        const teleporter = world.children[world._teleporters[0]] as ITeleporter;
 
-    expect(teleporter._links).toHaveLength(2);
-    expect(teleporter._links[1]).toEqual(link._uuid);
-  });
+        expect(teleporter._links).toHaveLength(2);
+        expect(teleporter._links[1]).toEqual(link._uuid);
+      });
 
-  it('should delete teleporter links', () => {
-    const world = parseBZWDocument(dedent`
-    teleporter tele1
-      pos 0 0 0
-      size 5 5 5
-    end
+      it('should delete teleporter links', () => {
+        const world = parseBZWDocument(dedent`
+          teleporter tele1
+            pos 0 0 0
+            size 5 5 5
+          end
 
-    teleporter tele2
-      pos 0 0 0
-      size 5 5 5
-    end
+          teleporter tele2
+            pos 0 0 0
+            size 5 5 5
+          end
 
-    teleporter tele3
-      pos 0 0 0
-      size 5 5 5
-    end
+          teleporter tele3
+            pos 0 0 0
+            size 5 5 5
+          end
 
-    link
-      from tele1:f
-      to tele1:f
-    end
+          link
+            from tele1:f
+            to tele1:f
+          end
 
-    link
-      from tele1:f
-      to tele2:f
-    end
+          link
+            from tele1:f
+            to tele2:f
+          end
 
-    link
-      from tele1:f
-      to tele3:f
-    end
-    `);
-    const teleUUID = world._teleporters[0];
-    const teleporter = world.children[teleUUID] as ITeleporter;
-    const linkUUID = teleporter._links[1];
+          link
+            from tele1:f
+            to tele3:f
+          end
+        `);
+        const teleUUID = world._teleporters[0];
+        const teleporter = world.children[teleUUID] as ITeleporter;
+        const linkUUID = teleporter._links[1];
 
-    const editor = new WorldEditorHelper(world);
-    editor.delLink(linkUUID).cleanUp();
+        const editor = new WorldEditorHelper(world);
+        editor.delLink(linkUUID).cleanUp();
 
-    const newLinks = (world.children[teleUUID] as ITeleporter)._links;
+        const newLinks = (world.children[teleUUID] as ITeleporter)._links;
 
-    expect(newLinks).toHaveLength(2);
-    expect(newLinks).not.toContain(linkUUID);
-    expect(world.children).not.toContain(linkUUID);
+        expect(newLinks).toHaveLength(2);
+        expect(newLinks).not.toContain(linkUUID);
+        expect(world.children).not.toContain(linkUUID);
+      });
+    });
+
+    describe('Teleporter Edits', () => {
+      it('should delete a teleporter and its links', () => {
+        const world = parseBZWDocument(dedent`
+          teleporter tele1
+            pos 0 0 0
+            size 5 5 5
+          end
+
+          teleporter tele2
+            pos 0 0 0
+            size 5 5 5
+          end
+
+          teleporter tele3
+            pos 0 0 0
+            size 5 5 5
+          end
+
+          link
+            from tele1:f
+            to tele2:f
+          end
+
+          link
+            from tele2:f
+            to tele1:f
+          end
+
+          link
+            from tele2:b
+            to tele3:f
+          end
+
+          link
+            from tele3:f
+            to tele1:f
+          end
+
+          link
+            from tele3:b
+            to tele1:b
+          end
+        `);
+        expect(world._teleporters).toHaveLength(3);
+
+        const teleUUID = world._teleporters[2];
+        const teleporter = world.children[teleUUID] as ITeleporter;
+
+        const startingLinks = Object.values(world.children).filter(
+          (child) => child._objectType === 'link',
+        );
+        expect(startingLinks).toHaveLength(5);
+
+        const editor = new WorldEditorHelper(world);
+        editor.delObstacle(teleporter);
+
+        expect(world._teleporters).toHaveLength(2);
+
+        const endingLinks = Object.values(world.children).filter(
+          (child) => child._objectType === 'link',
+        );
+        expect(endingLinks).toHaveLength(2);
+      });
+    });
   });
 });

--- a/src/Document/Utilities/__tests__/WorldEditorHelper.ts
+++ b/src/Document/Utilities/__tests__/WorldEditorHelper.ts
@@ -1,0 +1,96 @@
+import dedent from 'dedent';
+import { nanoid } from 'nanoid';
+
+import { ITeleporter } from '../../Obstacles/Teleporter';
+import {
+  newITeleporterLink,
+  TeleporterSide,
+} from '../../Obstacles/TeleporterLink';
+import { parseBZWDocument } from '../../parseBZWDocument';
+import { WorldEditorHelper } from '../WorldEditorHelper';
+
+describe('BZW Editor Helper', () => {
+  it('should add teleporter links', () => {
+    const world = parseBZWDocument(dedent`
+    teleporter tele1
+      pos 0 0 0
+      size 5 5 5
+    end
+
+    teleporter tele2
+      pos 0 0 0
+      size 5 5 5
+    end
+
+    link
+      from tele1:f
+      to tele2:f
+    end
+    `);
+    const link = {
+      ...newITeleporterLink(),
+      _uuid: nanoid(),
+      from: {
+        name: 'tele1',
+        side: TeleporterSide.Backward,
+      },
+      to: {
+        name: 'tele2',
+        side: TeleporterSide.Backward,
+      },
+    };
+    const helper = new WorldEditorHelper(world);
+    helper.addLink(link).cleanUp();
+
+    const teleporter = world.children[world._teleporters[0]] as ITeleporter;
+
+    expect(teleporter._links).toHaveLength(2);
+    expect(teleporter._links[1]).toEqual(link._uuid);
+  });
+
+  it('should delete teleporter links', () => {
+    const world = parseBZWDocument(dedent`
+    teleporter tele1
+      pos 0 0 0
+      size 5 5 5
+    end
+
+    teleporter tele2
+      pos 0 0 0
+      size 5 5 5
+    end
+
+    teleporter tele3
+      pos 0 0 0
+      size 5 5 5
+    end
+
+    link
+      from tele1:f
+      to tele1:f
+    end
+
+    link
+      from tele1:f
+      to tele2:f
+    end
+
+    link
+      from tele1:f
+      to tele3:f
+    end
+    `);
+    const teleUUID = world._teleporters[0];
+    const teleporter = world.children[teleUUID] as ITeleporter;
+    const linkUUID = teleporter._links[1];
+
+    const editor = new WorldEditorHelper(world);
+    editor.delLink(linkUUID).cleanUp();
+
+    const newLinks = (world.children[teleUUID] as ITeleporter)._links;
+
+    expect(newLinks).toHaveLength(2);
+    expect(newLinks).not.toContain(linkUUID);
+    expect(world.children).not.toContain(linkUUID);
+  });
+});

--- a/src/Document/attributeParsers.ts
+++ b/src/Document/attributeParsers.ts
@@ -109,7 +109,7 @@ export function bzwTeleRef(line: string, world: IWorld): TeleporterReference {
     const teleIndex = Math.floor(+name / 2),
       sideIndex = +name % 2;
 
-    name = world._teleporters[teleIndex].name ?? '';
+    name = world.children[world._teleporters[teleIndex]].name ?? '';
     side = sideIndex === 0 ? TeleporterSide.Forward : TeleporterSide.Backward;
   }
 

--- a/src/Document/parseBZWDocument.ts
+++ b/src/Document/parseBZWDocument.ts
@@ -77,9 +77,11 @@ const ObjectBuilders: Record<string, ObjectBuilder> = {
     onObstacleBegin: noop,
     onObstacleComplete: (link: ITeleporterLink, world) => {
       // after parsing a Link object, associate it with relevant teleporters
-      for (const tele of world._teleporters) {
+      for (const teleUUID of world._teleporters) {
+        const tele = world.children[teleUUID] as ITeleporter;
+
         if (tele.name === link.from.name || tele.name === link.to.name) {
-          tele._links.push(link);
+          tele._links.push(link._uuid);
         }
       }
     },
@@ -126,7 +128,7 @@ const ObjectBuilders: Record<string, ObjectBuilder> = {
       }
 
       // keep track of teleporter objects so we can associate their links later
-      world._teleporters.push(obstacle);
+      world._teleporters.push(obstacle._uuid);
     },
     onObstacleComplete: noop,
   },

--- a/src/Events/ITeleLinkEditorOpenEvent.ts
+++ b/src/Events/ITeleLinkEditorOpenEvent.ts
@@ -1,0 +1,21 @@
+import { ITeleporter } from '../Document/Obstacles/Teleporter';
+import { ITeleporterLink } from '../Document/Obstacles/TeleporterLink';
+
+export interface ITeleLinkEditorOpenEvent {
+  getTeleporter(): ITeleporter;
+  getTeleporterLinks(): ITeleporterLink[];
+}
+
+export const TeleLinkEditorOpenEventName = 'teleLinkEditorOpen';
+
+export class TeleLinkEditorOpenEvent implements ITeleLinkEditorOpenEvent {
+  constructor(private teleporter: ITeleporter) {}
+
+  getTeleporter(): ITeleporter {
+    return this.teleporter;
+  }
+
+  getTeleporterLinks(): ITeleporterLink[] {
+    return this.teleporter._links;
+  }
+}

--- a/src/Events/ITeleLinkEditorOpenEvent.ts
+++ b/src/Events/ITeleLinkEditorOpenEvent.ts
@@ -4,12 +4,18 @@ import { ITeleporterLink } from '../Document/Obstacles/TeleporterLink';
 export interface ITeleLinkEditorOpenEvent {
   getTeleporter(): ITeleporter;
   getTeleporterLinks(): ITeleporterLink[];
+  getFrontTeleporterLinks(): ITeleporterLink[];
+  getBackTeleporterLinks(): ITeleporterLink[];
 }
 
 export const TeleLinkEditorOpenEventName = 'teleLinkEditorOpen';
 
 export class TeleLinkEditorOpenEvent implements ITeleLinkEditorOpenEvent {
-  constructor(private teleporter: ITeleporter) {}
+  constructor(
+    private readonly teleporter: ITeleporter,
+    private readonly frontLinks: ITeleporterLink[],
+    private readonly backLinks: ITeleporterLink[],
+  ) {}
 
   getTeleporter(): ITeleporter {
     return this.teleporter;
@@ -17,5 +23,13 @@ export class TeleLinkEditorOpenEvent implements ITeleLinkEditorOpenEvent {
 
   getTeleporterLinks(): ITeleporterLink[] {
     return this.teleporter._links;
+  }
+
+  getFrontTeleporterLinks(): ITeleporterLink[] {
+    return this.frontLinks;
+  }
+
+  getBackTeleporterLinks(): ITeleporterLink[] {
+    return this.backLinks;
   }
 }

--- a/src/Events/ITeleLinkEditorOpenEvent.ts
+++ b/src/Events/ITeleLinkEditorOpenEvent.ts
@@ -3,7 +3,7 @@ import { ITeleporterLink } from '../Document/Obstacles/TeleporterLink';
 
 export interface ITeleLinkEditorOpenEvent {
   getTeleporter(): ITeleporter;
-  getTeleporterLinks(): ITeleporterLink[];
+  getTeleporterLinks(): string[];
   getFrontTeleporterLinks(): ITeleporterLink[];
   getBackTeleporterLinks(): ITeleporterLink[];
 }
@@ -21,7 +21,7 @@ export class TeleLinkEditorOpenEvent implements ITeleLinkEditorOpenEvent {
     return this.teleporter;
   }
 
-  getTeleporterLinks(): ITeleporterLink[] {
+  getTeleporterLinks(): string[] {
     return this.teleporter._links;
   }
 

--- a/src/Utilities/arrays.ts
+++ b/src/Utilities/arrays.ts
@@ -1,0 +1,15 @@
+/**
+ * @param arr
+ * @param value
+ *
+ * @link https://stackoverflow.com/a/5767357
+ */
+export function removeItem<T>(arr: Array<T>, value: T): Array<T> {
+  const index = arr.indexOf(value);
+
+  if (index > -1) {
+    arr.splice(index, 1);
+  }
+
+  return arr;
+}

--- a/src/Utilities/types.ts
+++ b/src/Utilities/types.ts
@@ -1,2 +1,9 @@
 export type Vector3F = [number, number, number];
 export type Vector4F = [number, number, number, number];
+
+/**
+ * @link https://github.com/microsoft/TypeScript/issues/10421#issuecomment-518806979
+ */
+export function assumeType<T>(_: unknown): asserts _ is T {
+  // ¯\_(ツ)_/¯
+}

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -1,10 +1,73 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
 
+import { ITeleporter } from './Document/Obstacles/Teleporter';
+import { ITeleporterLink } from './Document/Obstacles/TeleporterLink';
 import { IWorld } from './Document/Obstacles/World';
 
 export const documentState = atom<IWorld | null>({
   key: 'document',
   default: null,
+});
+
+/**
+ * A map of Teleporter names to their respective UUIDs
+ */
+export const documentTeles = selector<Record<string, string>>({
+  key: 'documentTeleporters',
+  get: ({ get }) => {
+    const world = get(documentState);
+
+    if (!world) {
+      return {};
+    }
+
+    const teleporters = world._teleporters;
+    const entries: Record<string, string> = {};
+
+    for (const teleUUID of teleporters) {
+      const teleporter = world.children[teleUUID] as ITeleporter;
+
+      if (!teleporter) {
+        continue;
+      }
+
+      entries[teleporter.name!] = teleUUID;
+    }
+
+    return entries;
+  },
+});
+
+export interface LinkToTeleRef {
+  teleUUID: string;
+}
+
+export const documentLinks = selector<Record<string, LinkToTeleRef>>({
+  key: 'documentLinks',
+  get: ({ get }) => {
+    const world = get(documentState);
+
+    if (!world) {
+      return {};
+    }
+
+    const teleMap = get(documentTeles);
+    const entries: Record<string, LinkToTeleRef> = {};
+
+    for (const teleUUID of world._teleporters) {
+      const teleporter = world.children[teleUUID] as ITeleporter;
+
+      for (const linkUUID of teleporter._links) {
+        const link = world.children[linkUUID] as ITeleporterLink;
+
+        entries[linkUUID] = {
+          teleUUID: teleMap[link.from.name],
+        };
+      }
+    }
+
+    return entries;
+  },
 });
 
 export const fileHandleState = atom<FileSystemFileHandle | null>({

--- a/src/sass/_utilities.scss
+++ b/src/sass/_utilities.scss
@@ -1,21 +1,3 @@
 .fw-normal {
   font-weight: normal;
 }
-
-.horizontal-checkbox {
-  cursor: pointer;
-  width: 100%;
-
-  input[type='checkbox'] {
-    margin-right: 5px;
-  }
-}
-
-.text-muted {
-  color: rgba(#fff, 0.5);
-}
-
-label {
-  display: block;
-  font-weight: bold;
-}

--- a/src/sass/a11yUtilities.module.scss
+++ b/src/sass/a11yUtilities.module.scss
@@ -1,0 +1,22 @@
+.srOnly {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.srFocusable {
+  &:active,
+  &:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+  }
+}

--- a/src/sass/alternatingGrid.module.scss
+++ b/src/sass/alternatingGrid.module.scss
@@ -1,0 +1,17 @@
+@import '../sass/variables';
+
+.container {
+  border-top: 1px solid rgba($color-white, 0.25);
+  margin-bottom: 0;
+}
+
+.listItem {
+  align-items: center;
+  border-bottom: 1px solid rgba($color-white, 0.25);
+  display: flex;
+  padding: 0.5rem 0.75rem;
+
+  &:nth-child(odd) {
+    background-color: #484848;
+  }
+}


### PR DESCRIPTION
Add an editor for managing teleporter links. It will live as a modal because it's too much logic to fit inside the toolbox panel.

A few other related changes,

- Add new `Alert` component
- Add new `TabList` component
- Changed `IWorld`'s `_teleporters` to be an array of UUIDs instead of objects (so that we don't have to update information in two separate locations since JS doesn't have references
- Changed `ITeleporter`'s `_links` to be an array of UUIDs for the same reason above
- Introduce new `WorldEditorHelper` to help make changes to the `IWorld` object, like adding or removing teleporter links
- Remove some unused, standalone CSS classes

## Known Bugs Left to Fix

- [x] Renaming a teleporter breaks all existing links
- [x] Don't allow naming teleporters with spaces