### PR TITLE
Fix incorrect server options

### DIFF
--- a/src/Document/Editor/FriendlyFireEditor.ts
+++ b/src/Document/Editor/FriendlyFireEditor.ts
@@ -12,7 +12,7 @@ export function getFriendlyFire(this: WorldEditorHelper): FriendlyFireMode {
     return FriendlyFireMode.WithPenalty;
   }
 
-  if (this.world._options['-noteamkills'] === true) {
+  if (this.world._options['-noTeamKills'] === true) {
     return FriendlyFireMode.Impossible;
   }
 
@@ -23,7 +23,7 @@ export function setFriendlyFire(
   this: WorldEditorHelper,
   mode: FriendlyFireMode,
 ): void {
-  const ffOpts: OptionsFlag[] = ['-noteamkills', '-tk'];
+  const ffOpts: OptionsFlag[] = ['-noTeamKills', '-tk'];
 
   for (const ffOpt of ffOpts) {
     delete this.world._options[ffOpt];
@@ -31,7 +31,7 @@ export function setFriendlyFire(
 
   switch (mode) {
     case FriendlyFireMode.Impossible:
-      this.world._options['-noteamkills'] = true;
+      this.world._options['-noTeamKills'] = true;
       break;
 
     case FriendlyFireMode.WithPenalty:

--- a/src/Document/Editor/__tests__/WorldEditorHelper.ts
+++ b/src/Document/Editor/__tests__/WorldEditorHelper.ts
@@ -343,7 +343,7 @@ describe('BZW Editor Helper', () => {
           description: 'should result in an "impossible" friendly fire mode',
           world: bzw`
             options
-              -noteamkills
+              -noTeamKills
             end
           `,
           expected: FriendlyFireMode.Impossible,
@@ -389,7 +389,7 @@ describe('BZW Editor Helper', () => {
             end
 
             options
-              -noteamkills
+              -noTeamKills
             end
           `,
         },

--- a/src/Document/Obstacles/Option.ts
+++ b/src/Document/Obstacles/Option.ts
@@ -108,7 +108,7 @@ export function bzwFlag(input: string): FlagCount {
 export const OptionsProperties = {
   '-a': bzwAccelerations,
   '-admsg': bzwRepeatable(bzwString),
-  '-autoteam': bzwBool,
+  '-autoTeam': bzwBool,
   '-c': bzwBool,
   '+f': bzwRepeatable(bzwFlag),
   '-f': bzwRepeatable(bzwString),
@@ -140,7 +140,7 @@ export const OptionsProperties = {
 export interface IOptions extends IBaseObject {
   '-a'?: Accelerations;
   '-admsg'?: string[];
-  '-autoteam'?: boolean;
+  '-autoTeam'?: boolean;
   '-c'?: boolean;
   '-fb'?: boolean;
   '+f'?: FlagCount[];

--- a/src/Document/Obstacles/Option.ts
+++ b/src/Document/Obstacles/Option.ts
@@ -121,7 +121,7 @@ export const OptionsProperties = {
   '-mps': bzwInt,
   '-ms': bzwInt,
   '-mts': bzwInt,
-  '-noteamkills': bzwBool,
+  '-noTeamKills': bzwBool,
   '-offa': bzwBool,
   '+r': bzwBool,
   '-rabbit': bzwRabbitMode,
@@ -153,7 +153,7 @@ export interface IOptions extends IBaseObject {
   '-mps'?: number;
   '-ms'?: number;
   '-mts'?: number;
-  '-noteamkills'?: boolean;
+  '-noTeamKills'?: boolean;
   '-offa'?: boolean;
   '+r'?: boolean;
   '-rabbit'?: RabbitMode;

--- a/src/Document/__tests__/parseBZWDocument.ts
+++ b/src/Document/__tests__/parseBZWDocument.ts
@@ -483,7 +483,7 @@ describe('BZW Document Parser', () => {
       -a 12 45
       -admsg there is a snake in my boot!
       -admsg execute order 66
-      -autoteam
+      -autoTeam
       -c
       +f 23{34}
       +f bad{69}
@@ -528,7 +528,7 @@ describe('BZW Document Parser', () => {
       'there is a snake in my boot!',
       'execute order 66',
     ]);
-    expect(option['-autoteam']).toEqual(true);
+    expect(option['-autoTeam']).toEqual(true);
     expect(option['-c']).toEqual(true);
     expect(option['+f']).toEqual([
       { flag: '23', count: 34 } as FlagCount,

--- a/src/Document/__tests__/parseBZWDocument.ts
+++ b/src/Document/__tests__/parseBZWDocument.ts
@@ -501,7 +501,7 @@ describe('BZW Document Parser', () => {
       -mps 420
       -ms 1011
       -mts 777
-      -noteamkills
+      -noTeamKills
       -offa
       +r
       -rabbit killer
@@ -552,7 +552,7 @@ describe('BZW Document Parser', () => {
     expect(option['-mps']).toEqual(420);
     expect(option['-ms']).toEqual(1011);
     expect(option['-mts']).toEqual(777);
-    expect(option['-noteamkills']).toEqual(true);
+    expect(option['-noTeamKills']).toEqual(true);
     expect(option['-offa']).toEqual(true);
     expect(option['+r']).toEqual(true);
     expect(option['-rabbit']).toEqual('killer' as RabbitMode);

--- a/src/Document/__tests__/writeBZWDocument.ts
+++ b/src/Document/__tests__/writeBZWDocument.ts
@@ -374,7 +374,7 @@ describe('BZW Document Writer', () => {
           '-mps': 100,
           '-ms': 5,
           '-mts': 512,
-          '-noteamkills': true,
+          '-noTeamKills': true,
           '-offa': true,
           '+r': true,
           '-rabbit': 'killer',
@@ -433,7 +433,7 @@ describe('BZW Document Writer', () => {
         -mps 100
         -ms 5
         -mts 512
-        -noteamkills
+        -noTeamKills
         -offa
         +r
         -rabbit killer

--- a/src/Document/__tests__/writeBZWDocument.ts
+++ b/src/Document/__tests__/writeBZWDocument.ts
@@ -338,7 +338,7 @@ describe('BZW Document Writer', () => {
             angular: 38,
           },
           '-admsg': ['Welcome to my wonder map!', '  by blast'],
-          '-autoteam': true,
+          '-autoTeam': true,
           '-c': true,
           '+f': [
             {
@@ -417,7 +417,7 @@ describe('BZW Document Writer', () => {
         -a 50 38
         -admsg "Welcome to my wonder map!"
         -admsg "  by blast"
-        -autoteam
+        -autoTeam
         -c
         +f G{10}
         +f US{50}


### PR DESCRIPTION
Fixes a problem where the option to remove teamkills was incorrect causing errors when loading such a map on a server.